### PR TITLE
Set protocol to HTTPS for CDNs to avoid blocked mixed content

### DIFF
--- a/project/templates/_base.html
+++ b/project/templates/_base.html
@@ -8,7 +8,7 @@
     <meta name="author" content="">
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <!-- styles -->
-    <link href="http://maxcdn.bootstrapcdn.com/bootswatch/3.2.0/yeti/bootstrap.min.css" rel="stylesheet" media="screen">
+    <link href="//maxcdn.bootstrapcdn.com/bootswatch/3.2.0/yeti/bootstrap.min.css" rel="stylesheet" media="screen">
     <link href="{{url_for('static', filename='main.css')}}" rel="stylesheet" media="screen">
     {% block css %}{% endblock %}
   </head>
@@ -49,8 +49,8 @@
     </div>
 
     <!-- scripts -->
-    <script src="https://code.jquery.com/jquery-2.1.1.min.js" type="text/javascript"></script>
-    <script src="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js" type="text/javascript"></script>
+    <script src="//code.jquery.com/jquery-2.1.1.min.js" type="text/javascript"></script>
+    <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js" type="text/javascript"></script>
     <script src="{{url_for('static', filename='main.js')}}" type="text/javascript"></script>
     {% block js %}{% endblock %}
 


### PR DESCRIPTION
As per title, serving the application over HTTPS, the files served over HTTP are blocked as per the [blocking of mixed content policy][1]. The [suggested fix][1] is switching the sources to HTTPS («For other domains, use the site's HTTPS version if available»).

[1]: https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content/How_to_fix_website_with_mixed_content